### PR TITLE
Use Chiang Mai as default location

### DIFF
--- a/src/app/widget.service.ts
+++ b/src/app/widget.service.ts
@@ -65,8 +65,12 @@ export class WidgetService {
       navigator.geolocation.getCurrentPosition(resp => {
         resolve({ lng: resp.coords.longitude, lat: resp.coords.latitude });
       },
-        err => {
-          reject(err);
+        () => {
+          console.log(`User doesn't allow the location service. Using Chiang Mai as default location.`)
+          resolve({
+            lng: 98.979263,
+            lat: 18.796143
+          })
         });
     });
   }


### PR DESCRIPTION
The smog season begins. More people are accessing the web. I think we should not leave the metrics empty. Thus, we should use Chiang Mai as a default location.